### PR TITLE
support dynamic client secrets

### DIFF
--- a/docs/examples/resource_owner_grant.py
+++ b/docs/examples/resource_owner_grant.py
@@ -28,8 +28,8 @@ class ClientApplication(object):
     Very basic application that simulates calls to the API of the
     oauth2-stateless app.
     """
-    client_id = "abc"
-    client_secret = "xyz"
+    client_id = "cba"
+    client_secret = "zyx"
     token_endpoint = "http://localhost:8081/token"
 
     LOGIN_TEMPLATE = """<html>
@@ -179,7 +179,7 @@ def run_app_server():
 def run_auth_server():
     try:
         client_store = ClientStore()
-        client_store.add_client(client_id="abc", client_secret="xyz", redirect_uris=[])
+        client_store.add_client(client_id="cba", client_secret=lambda s: s == 'zyx', redirect_uris=[])
 
         token_store = TokenStore()
 

--- a/oauth2/client_authenticator.py
+++ b/oauth2/client_authenticator.py
@@ -84,6 +84,8 @@ class ClientAuthenticator(object):
                                     explanation="The client is not allowed to use this grant type")
 
         if client.secret != client_secret:
+            if callable(client.secret) and client.secret(client_secret) == True:
+                return client
             raise OAuthInvalidError(error="invalid_client", explanation="Invalid client credentials")
 
         return client


### PR DESCRIPTION
If client.secret is callable, call it with the client_secret passed by the OAuth2 client to allow dynamic verification.

The use case is to allow more complex stateless clients.